### PR TITLE
Fix glob with star and double star

### DIFF
--- a/internal/services/common/path/glob.go
+++ b/internal/services/common/path/glob.go
@@ -19,7 +19,12 @@ func glob(pattern string) ([]string, error) {
 		// passthru to core package if no double-star
 		return filepath.Glob(pattern)
 	}
-	return globs(strings.Split(pattern, "**")).expand()
+	split := strings.Split(pattern, "**")
+	for i, s := range split {
+		split[i] = strings.TrimRight(s, "/")
+	}
+
+	return globs(split).expand()
 }
 
 // expand finds matches for the provided globs.

--- a/test/check/arch1_nested_glob.ct
+++ b/test/check/arch1_nested_glob.ct
@@ -1,0 +1,8 @@
+$ go-arch-lint check --project-path ${PWD}/test/check/project --arch-file arch1_nested_glob.yml --output-color=false
+module: github.com/fe3dback/go-arch-lint/test/check/project
+linters:
+   On | Base: component imports # always on
+   On | Advanced: vendor imports # switch 'allow.depOnAnyVendor = false' (or delete) to on
+  Off | Advanced: method calls and dependency injections # switch 'allow.deepScan = true' (or delete) to on
+
+OK - No warnings found

--- a/test/check/project/arch1_nested_glob.yml
+++ b/test/check/project/arch1_nested_glob.yml
@@ -1,0 +1,57 @@
+version: 1
+
+allow:
+  depOnAnyVendor: false
+
+exclude:
+  - internal/excluded
+  - vendor
+
+excludeFiles:
+  - "^.*_test\\.go$"
+
+components:
+  main:
+    in: internal
+
+  a:
+    in: internal/a
+
+  allowb:
+    in: internal/a/allowb
+
+  b:
+    in: internal/b
+
+  c:
+    in: internal/c/**
+
+  e:
+    in: internal/e/**
+
+  d:
+    in: internal/d/**
+
+  nc:
+    in: internal/not_covered
+
+  common:
+    in: internal/common/**
+
+  models:
+    in: internal/*/models/**
+
+commonComponents:
+  - common
+  - a
+  - c
+  - models
+  - e
+
+deps:
+  allowb:
+    mayDependOn:
+      - b
+
+  e:
+    anyVendorDeps: true


### PR DESCRIPTION
The code, that's used to deeply nest by glob patterns doesn't strip excess `/` from the globs after splitting them by double stars. This results in pattern `dir/` which doesn't match the `dir` itself (see https://go.dev/play/p/aLibWhLw9vd), thus code doesn't recurse inside the directory and returns empty set of directories

Closes #47 