### PR TITLE
Add pre-commit support

### DIFF
--- a/.pre-commit-hooks.yaml
+++ b/.pre-commit-hooks.yaml
@@ -1,0 +1,6 @@
+- id: go-arch-lint
+  name: Check Go repo architecture
+  description: Check Go repo architecture using go-arch-lint
+  entry: go-arch-lint check
+  language: golang
+  pass_filenames: false

--- a/.pre-commit-hooks.yaml
+++ b/.pre-commit-hooks.yaml
@@ -1,6 +1,13 @@
-- id: go-arch-lint
+- id: go-arch-lint-check
   name: Check Go repo architecture
   description: Check Go repo architecture using go-arch-lint
   entry: go-arch-lint check
+  language: golang
+  pass_filenames: false
+
+- id: go-arch-lint-graph
+  name: Generate graph for Go repo architecture
+  description: Generate graph for Go repo architecture using go-arch-lint
+  entry: go-arch-lint graph
   language: golang
   pass_filenames: false

--- a/README.md
+++ b/README.md
@@ -162,3 +162,27 @@ go-arch-lint graph
 ```
 
 See full [graph documentation](docs/graph/README.md) for details.
+
+### Pre-Commit
+
+go-arch-lint can also be used as a pre-commit hook, acting before each commit is made.  
+This is useful to always check that your new code still respects your repo architecture, and to always update your graph SVG.
+
+1. Install pre-commit from [https://pre-commit.com/#install](https://pre-commit.com/#install)
+2. Create a `.pre-commit-config.yaml` file at the root of your repository with the following content:
+
+```go
+repos:
+  - repo: https://github.com/fe3dback/go-arch-lint
+    rev: master
+    hooks:
+      - id: go-arch-lint-check
+      - id: go-arch-lint-graph
+        args: ['--include-vendors=true', '--out=go-arch-lint-graph.svg']
+```
+
+3. If needed, add any flags you need in `args`.
+4. Auto-update the config to the latest repos' versions by executing `pre-commit autoupdate`
+5. Install with `pre-commit install`
+6. Now you're all set! Try a commit, and see the logs (passing or failing).
+


### PR DESCRIPTION
[pre-commit](https://github.com/pre-commit/pre-commit) is "A framework for managing and maintaining multi-language pre-commit hooks", kinda like a local CI. It's a popular tool with a lot of community-made hooks.
I thought it would be very handy to have pre-commit support in go-arch-lint, allowing to check the repo compliance before each commit, and to keep a graph SVG updated (optional).

The PR only consists of a new file used by pre-commit, and the new instructions in README. It has no impact on go-arch-lint itself.  
I tested it on a private repo and it works well, here are some screenshots:
![precommit-failing](https://github.com/fe3dback/go-arch-lint/assets/10067226/c89e4436-b74c-41fb-a4b1-078f4eb263e5)  
![precommit-passing](https://github.com/fe3dback/go-arch-lint/assets/10067226/fa6a5e7f-b02f-459d-a199-c9c682e279d5)

You can also test it by yourself easily by following the new README instructions. Just replace these 2 lines in `.pre-commit-config.yaml`:
```diff
-  - repo: https://github.com/fe3dback/go-arch-lint
-    rev: master
+  - repo: https://github.com/alexandregv/go-arch-lint
+    rev: 554d29e9ee758eb8e449d41673d890156389e305
```
(since it's not merged you must use my fork)

Hope you find it useful :)