### PR TITLE
fix: improve package matching for imports

### DIFF
--- a/internal/services/project/scanner/scanner.go
+++ b/internal/services/project/scanner/scanner.go
@@ -142,7 +142,9 @@ func (r *Scanner) getImportType(ctx *resolveContext, importPath string) models.I
 		return models.ImportTypeStdLib
 	}
 
-	if strings.HasPrefix(importPath, ctx.moduleName) {
+	// We can't use a straight prefix match here because the module name could be a substring of the import path.
+	// For example, if the module name is "example.com/foo/bar", we do not want to match "example.com/foo/bar-utils"
+	if importPath == ctx.moduleName || strings.HasPrefix(importPath, ctx.moduleName+"/") {
 		return models.ImportTypeProject
 	}
 


### PR DESCRIPTION
I am running into an issue where github.com/foo/bar-tools is being considered a local import for github.com/foo/bar. If this PR is ok is there any chance you could create a release with the fix?