### PR TITLE
chore: update Go to 1.24 to resolve the build error

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -27,7 +27,7 @@ jobs:
         if: steps.check-tag.outputs.match == 'true'
         uses: actions/setup-go@v2
         with:
-          go-version: 1.18
+          go-version: 1.24
       -
         name: Docker Login
         if: success() && steps.check-tag.outputs.match == 'true'


### PR DESCRIPTION
The release v1.11.8 failed because the version of Go was too old (v1.18.0).

https://github.com/fe3dback/go-arch-lint/releases/tag/v1.11.8
https://github.com/fe3dback/go-arch-lint/actions/runs/13710094273/job/38344571507

```
Error:     │ build failed: exit status 1: ../../../go/pkg/mod/golang.org/x/tools@v0.30.0/go/packages/external.go:16:2: package slices is not in GOROOT (/opt/hostedtoolcache/go/1.18.10/x64/src/slices)
    target=linux_arm64_v8.0
```

slices package requires Go 1.21 or newer.

## Test

The release succeeded.

https://github.com/suzuki-shunsuke/go-arch-lint/actions/runs/13719517471/job/38371666569
https://github.com/suzuki-shunsuke/go-arch-lint/releases/tag/v1.11.9