### PR TITLE
ISSUE-67: Deepscan ignores anyProjectDeps flag

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -1,0 +1,92 @@
+# More info: https://golangci-lint.run/docs/configuration/file/
+version: "2"
+
+run:
+  tests: true
+  go: "1.25"
+  build-tags:
+    - integration
+
+output:
+  formats:
+    text:
+      print-issued-lines: true
+      print-linter-name: true
+
+linters:
+  # v2: вместо disable-all используем default: none
+  default: none
+  enable:
+    # Базовые качество/стиль
+    - unused                        # Неиспользуемые константы/переменные/функции/типы
+    - staticcheck                   # Большой набор проверок (honnef.co/go/tools)
+    - govet                         # Встроенный "go vet": подозрительные конструкции
+    - revive                        # Гибкий стилевой линтер (на замену golint)
+    - whitespace                    # Лишние пустые строки в начале/конце блоков и т.п.
+    - asciicheck                    # ASCII-только: стиль идентификаторов/комментариев
+    - misspell                      # Опечатки в комментариях/строках
+    - dupword                       # Повторяющиеся слова
+    - decorder                      # Порядок объявлений (const/type/var/func)
+    - goconst                       # Повторяющиеся литералы → константы
+    - tagalign                      # Выравнивание тегов структур
+
+    # Ошибки и обработка ошибок
+    - errcheck                      # Непроверенные ошибки
+    - errorlint                     # Правильная работа с обёртками ошибок (Go 1.13+)
+    - errname                       # Имена ошибок: Err* / *Error
+
+    # Контекст/конкурентность/тесты
+    - copyloopvar                   # Копирование переменной цикла (замыкания/го‑рутины)
+
+    # Производственный код/практики
+    - ineffassign                   # Присваивания без использования
+    - wastedassign                  # "Бесполезные" присваивания
+    - unconvert                     # Лишние преобразования типов
+    - predeclared                   # Затенение предобъявленных идентификаторов
+    - makezero                      # make с ненулевой длиной
+    - gochecknoinits                # Запрещает init(): больше предсказуемости и тестопригодности
+    - gosec                         # Статический анализ на уязвимости (безопасность)
+
+  settings:
+    revive:
+      rules:
+        - name: var-naming
+          disabled: true
+    unused:
+      field-writes-are-uses: false
+  exclusions:
+    generated: lax
+    presets:
+      - comments
+      - common-false-positives
+      - legacy
+      - std-error-handling
+    paths:
+      - third_party$
+      - builtin$
+      - examples$
+issues:
+  max-issues-per-linter: 0
+  max-same-issues: 0
+
+# В v2 форматтеры выделены отдельно и могут участвовать в `run` как проверки.
+formatters:
+  enable:
+    - gci
+    - gofumpt
+  settings:
+    gci:
+      sections:
+        - standard
+        - default
+        - localmodule
+  # Исключения директорий для форматтеров дублируем, как рекомендует миграция
+  exclusions:
+    generated: lax
+    paths:
+      - third_party$
+      - builtin$
+      - examples$
+      - bin
+      - var
+      - tmp

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:1.20-buster
+FROM golang:1.25
 
 # currently we use `packages.Load(..)` feature of go AST parser
 # this require go binary and some random files from go setup

--- a/README.md
+++ b/README.md
@@ -75,7 +75,7 @@ docker run --rm -v ${PWD}:/app fe3dback/go-arch-lint:latest-stable-release check
 [other docker tags and versions](https://hub.docker.com/r/fe3dback/go-arch-lint/tags)
 
 #### From sources
-It requires go 1.24+
+It requires go 1.25+
 
 ```bash
 go install github.com/fe3dback/go-arch-lint@latest

--- a/go.mod
+++ b/go.mod
@@ -1,8 +1,6 @@
 module github.com/fe3dback/go-arch-lint
 
-go 1.24.0
-
-toolchain go1.24.5
+go 1.25.0
 
 require (
 	github.com/alecthomas/chroma v0.10.0

--- a/internal/app/build_consts.go
+++ b/internal/app/build_consts.go
@@ -3,7 +3,7 @@ package app
 import "github.com/fe3dback/go-arch-lint/internal/models"
 
 var (
-	Version    = models.UnknownVersion // nolint
-	BuildTime  = "unknown"             // nolint
-	CommitHash = "unknown"             // nolint
+	Version    = models.UnknownVersion
+	BuildTime  = "unknown"
+	CommitHash = "unknown"
 )

--- a/internal/app/cli.go
+++ b/internal/app/cli.go
@@ -23,7 +23,6 @@ func Execute() int {
 
 	// -- process
 	err := di.CommandRoot().ExecuteContext(mainCtx)
-
 	// -- handle errors
 	if err != nil {
 		if errors.Is(err, models.UserSpaceError{}) {

--- a/internal/app/internal/container/cnt_utils.go
+++ b/internal/app/internal/container/cnt_utils.go
@@ -1,10 +1,10 @@
 package container
 
 import (
-	"github.com/fe3dback/go-arch-lint/internal/services/render/printer"
 	"github.com/logrusorgru/aurora/v3"
 
 	"github.com/fe3dback/go-arch-lint/internal/services/render"
+	"github.com/fe3dback/go-arch-lint/internal/services/render/printer"
 	"github.com/fe3dback/go-arch-lint/internal/view"
 )
 

--- a/internal/app/internal/container/container_cmd.go
+++ b/internal/app/internal/container/container_cmd.go
@@ -4,8 +4,9 @@ import (
 	"fmt"
 	"strings"
 
-	"github.com/fe3dback/go-arch-lint/internal/models"
 	"github.com/spf13/cobra"
+
+	"github.com/fe3dback/go-arch-lint/internal/models"
 )
 
 type runner = func(cmd *cobra.Command) (any, error)
@@ -115,7 +116,6 @@ func (c *Container) commands() []*cobra.Command {
 
 	list := make([]*cobra.Command, 0, len(executors))
 	for _, x := range executors {
-		x := x
 		x.cmd.RunE = func(activeCmd *cobra.Command, _ []string) error {
 			return c.ProvideRenderer().RenderModel(x.runE(activeCmd))
 		}

--- a/internal/app/internal/container/container_cmd.go
+++ b/internal/app/internal/container/container_cmd.go
@@ -115,11 +115,12 @@ func (c *Container) commands() []*cobra.Command {
 	}
 
 	list := make([]*cobra.Command, 0, len(executors))
-	for _, x := range executors {
-		x.cmd.RunE = func(activeCmd *cobra.Command, _ []string) error {
-			return c.ProvideRenderer().RenderModel(x.runE(activeCmd))
+	for i := range executors {
+		executor := executors[i]
+		executor.cmd.RunE = func(activeCmd *cobra.Command, _ []string) error {
+			return c.ProvideRenderer().RenderModel(executor.runE(activeCmd))
 		}
-		list = append(list, x.cmd)
+		list = append(list, executor.cmd)
 	}
 
 	return list

--- a/internal/app/internal/container/container_cmd_check.go
+++ b/internal/app/internal/container/container_cmd_check.go
@@ -3,9 +3,10 @@ package container
 import (
 	"fmt"
 
+	"github.com/spf13/cobra"
+
 	"github.com/fe3dback/go-arch-lint/internal/models"
 	"github.com/fe3dback/go-arch-lint/internal/operations/check"
-	"github.com/spf13/cobra"
 )
 
 func (c *Container) commandCheck() (*cobra.Command, runner) {

--- a/internal/app/internal/container/container_cmd_graph.go
+++ b/internal/app/internal/container/container_cmd_graph.go
@@ -4,9 +4,10 @@ import (
 	"fmt"
 	"strings"
 
+	"github.com/spf13/cobra"
+
 	"github.com/fe3dback/go-arch-lint/internal/models"
 	"github.com/fe3dback/go-arch-lint/internal/operations/graph"
-	"github.com/spf13/cobra"
 )
 
 func (c *Container) commandGraph() (*cobra.Command, runner) {

--- a/internal/app/internal/container/container_cmd_mapping.go
+++ b/internal/app/internal/container/container_cmd_mapping.go
@@ -4,9 +4,10 @@ import (
 	"fmt"
 	"strings"
 
+	"github.com/spf13/cobra"
+
 	"github.com/fe3dback/go-arch-lint/internal/models"
 	"github.com/fe3dback/go-arch-lint/internal/operations/mapping"
-	"github.com/spf13/cobra"
 )
 
 func (c *Container) commandMapping() (*cobra.Command, runner) {

--- a/internal/app/internal/container/container_cmd_schema.go
+++ b/internal/app/internal/container/container_cmd_schema.go
@@ -3,9 +3,10 @@ package container
 import (
 	"fmt"
 
+	"github.com/spf13/cobra"
+
 	"github.com/fe3dback/go-arch-lint/internal/models"
 	"github.com/fe3dback/go-arch-lint/internal/operations/schema"
-	"github.com/spf13/cobra"
 )
 
 func (c *Container) commandSchema() (*cobra.Command, runner) {

--- a/internal/app/internal/container/container_cmd_self_inspect.go
+++ b/internal/app/internal/container/container_cmd_self_inspect.go
@@ -1,9 +1,10 @@
 package container
 
 import (
+	"github.com/spf13/cobra"
+
 	"github.com/fe3dback/go-arch-lint/internal/models"
 	"github.com/fe3dback/go-arch-lint/internal/operations/selfInspect"
-	"github.com/spf13/cobra"
 )
 
 func (c *Container) commandSelfInspect() (*cobra.Command, runner) {

--- a/internal/app/internal/container/container_cmd_version.go
+++ b/internal/app/internal/container/container_cmd_version.go
@@ -1,8 +1,9 @@
 package container
 
 import (
-	"github.com/fe3dback/go-arch-lint/internal/operations/version"
 	"github.com/spf13/cobra"
+
+	"github.com/fe3dback/go-arch-lint/internal/operations/version"
 )
 
 func (c *Container) commandVersion() (*cobra.Command, runner) {

--- a/internal/models/common/reference.go
+++ b/internal/models/common/reference.go
@@ -98,19 +98,19 @@ func (r Reference) guaranteeValidState(mutate func(r *Reference)) Reference {
 }
 
 func clampInt(num, a, b int) int {
-	min, max := sortInt(a, b)
+	minimum, maximum := sortInt(a, b)
 
-	if num < min {
-		num = min
+	if num < minimum {
+		num = minimum
 	}
-	if num > max {
-		num = max
+	if num > maximum {
+		num = maximum
 	}
 
 	return num
 }
 
-func sortInt(a, b int) (min, max int) {
+func sortInt(a, b int) (minimum, maximum int) {
 	if a > b {
 		return b, a
 	}

--- a/internal/models/errors.go
+++ b/internal/models/errors.go
@@ -7,7 +7,7 @@ type (
 		msg string
 	}
 
-	ReferableErr struct {
+	ReferableError struct {
 		original  error
 		reference common.Reference
 	}
@@ -17,11 +17,11 @@ func (u UserSpaceError) Error() string {
 	return u.msg
 }
 
-func (r ReferableErr) Error() string {
+func (r ReferableError) Error() string {
 	return r.original.Error()
 }
 
-func (r ReferableErr) Reference() common.Reference {
+func (r ReferableError) Reference() common.Reference {
 	return r.reference
 }
 
@@ -37,12 +37,12 @@ func (u UserSpaceError) Is(err error) bool {
 	return false
 }
 
-func (r ReferableErr) Is(err error) bool {
+func (r ReferableError) Is(err error) bool {
 	if err == nil {
 		return false
 	}
 
-	if _, ok := err.(ReferableErr); ok {
+	if _, ok := err.(ReferableError); ok {
 		return true
 	}
 
@@ -55,8 +55,8 @@ func NewUserSpaceError(msg string) UserSpaceError {
 	}
 }
 
-func NewReferableErr(err error, ref common.Reference) ReferableErr {
-	return ReferableErr{
+func NewReferableErr(err error, ref common.Reference) ReferableError {
+	return ReferableError{
 		original:  err,
 		reference: ref,
 	}

--- a/internal/models/resolved_file.go
+++ b/internal/models/resolved_file.go
@@ -1,6 +1,10 @@
 package models
 
-import "github.com/fe3dback/go-arch-lint/internal/models/common"
+import (
+	"strings"
+
+	"github.com/fe3dback/go-arch-lint/internal/models/common"
+)
 
 const (
 	ImportTypeStdLib ImportType = iota
@@ -27,3 +31,18 @@ type (
 		Reference  common.Reference
 	}
 )
+
+// GetImportType classifies an import path as std, project, or vendor
+func GetImportType(importPath string, moduleName string, stdPackages map[string]struct{}) ImportType {
+	if _, ok := stdPackages[importPath]; ok {
+		return ImportTypeStdLib
+	}
+
+	// We can't use a straight prefix match here because the module name could be a substring of the import path.
+	// For example, if the module name is "example.com/foo/bar", we do not want to match "example.com/foo/bar-utils"
+	if importPath == moduleName || strings.HasPrefix(importPath, moduleName+"/") {
+		return ImportTypeProject
+	}
+
+	return ImportTypeVendor
+}

--- a/internal/operations/check/operation.go
+++ b/internal/operations/check/operation.go
@@ -79,13 +79,13 @@ func (o *Operation) Behave(ctx context.Context, in models.CmdCheckIn) (models.Cm
 			{
 				ID:   "vendor_imports",
 				Name: "Advanced: vendor imports",
-				Used: spec.Allow.DepOnAnyVendor.Value == false,
+				Used: !spec.Allow.DepOnAnyVendor.Value,
 				Hint: "switch 'allow.depOnAnyVendor = false' (or delete) to on",
 			},
 			{
 				ID:   "deepscan",
 				Name: "Advanced: method calls and dependency injections",
-				Used: spec.Allow.DeepScan.Value == true,
+				Used: spec.Allow.DeepScan.Value,
 				Hint: "switch 'allow.deepScan = true' (or delete) to on",
 			},
 		},

--- a/internal/operations/graph/operation.go
+++ b/internal/operations/graph/operation.go
@@ -9,15 +9,15 @@ import (
 	"sort"
 	"strings"
 
-	"github.com/fe3dback/go-arch-lint/internal/models"
-	"github.com/fe3dback/go-arch-lint/internal/models/arch"
-	"oss.terrastruct.com/d2/d2themes/d2themescatalog"
-	"oss.terrastruct.com/d2/lib/textmeasure"
-
 	"oss.terrastruct.com/d2/d2graph"
 	"oss.terrastruct.com/d2/d2layouts/d2dagrelayout"
 	"oss.terrastruct.com/d2/d2lib"
 	"oss.terrastruct.com/d2/d2renderers/d2svg"
+	"oss.terrastruct.com/d2/d2themes/d2themescatalog"
+	"oss.terrastruct.com/d2/lib/textmeasure"
+
+	"github.com/fe3dback/go-arch-lint/internal/models"
+	"github.com/fe3dback/go-arch-lint/internal/models/arch"
 )
 
 type Operation struct {
@@ -62,7 +62,7 @@ func (o *Operation) Behave(ctx context.Context, in models.CmdGraphIn) (models.Cm
 	}
 
 	if o.isFileShouldBeWritten(in) {
-		err = os.WriteFile(outFile, svg, os.ModePerm)
+		err = os.WriteFile(outFile, svg, 0o600)
 		if err != nil {
 			return models.CmdGraphOut{}, fmt.Errorf("failed write graph into '%s' file: %w", in.OutFile, err)
 		}

--- a/internal/services/checker/checker_deepscan.go
+++ b/internal/services/checker/checker_deepscan.go
@@ -9,11 +9,12 @@ import (
 	"strings"
 	"sync"
 
+	"golang.org/x/sync/errgroup"
+
 	"github.com/fe3dback/go-arch-lint/internal/models"
 	"github.com/fe3dback/go-arch-lint/internal/models/arch"
 	"github.com/fe3dback/go-arch-lint/internal/models/common"
 	"github.com/fe3dback/go-arch-lint/internal/services/checker/deepscan"
-	"golang.org/x/sync/errgroup"
 )
 
 type DeepScan struct {
@@ -71,8 +72,8 @@ func (c *DeepScan) workersCount() int {
 func (c *DeepScan) Check(ctx context.Context, spec arch.Spec) (models.CheckResult, error) {
 	maxWorkers := c.workersCount()
 
-	c.Mutex.Lock()
-	defer c.Mutex.Unlock()
+	c.Lock()
+	defer c.Unlock()
 
 	// -- prepare shared objects
 	c.spec = spec
@@ -105,15 +106,13 @@ func (c *DeepScan) Check(ctx context.Context, spec arch.Spec) (models.CheckResul
 	var wg errgroup.Group
 
 	for _, component := range spec.Components {
-		component := component
-
 		pool <- struct{}{}
 		wg.Go(func() error {
 			defer func() {
 				<-pool
 			}()
 
-			if component.DeepScan.Value != true {
+			if !component.DeepScan.Value {
 				return nil
 			}
 
@@ -210,7 +209,7 @@ func (c *DeepScan) checkGate(_ context.Context, cmp *arch.Component, gate *deeps
 	for _, implementation := range gate.Implementations {
 		err := c.checkImplementation(cmp, gate, &implementation)
 		if err != nil {
-			return fmt.Errorf("failed check implementation '%s': %w",
+			return fmt.Errorf("failed check implementation '%v': %w",
 				implementation.Injector.ParamDefinition,
 				err,
 			)
@@ -227,10 +226,19 @@ func (c *DeepScan) checkImplementation(
 ) error {
 	injectedImport := imp.Target.Definition.Import
 
+	// allow explicitly allowed project imports
 	for _, allowedImport := range cmp.AllowedProjectImports {
-		if allowedImport.Value.ImportPath == injectedImport {
+		if allowedImport.Value.ImportPath == injectedImport.Name {
 			return nil
 		}
+	}
+
+	// allow by special flags per import type
+	if cmp.SpecialFlags.AllowAllProjectDeps.Value && injectedImport.ImportType == models.ImportTypeProject {
+		return nil
+	}
+	if cmp.SpecialFlags.AllowAllVendorDeps.Value && injectedImport.ImportType == models.ImportTypeVendor {
+		return nil
 	}
 
 	targetPath := imp.Target.Definition.Place.File
@@ -287,14 +295,6 @@ func (c *DeepScan) renderCode(pointer, from, to common.Reference) []byte {
 		false,
 		false,
 	)
-}
-
-func (c *DeepScan) sortPositions(a, b common.Reference) (min, max common.Reference) {
-	if a.Line < b.Line {
-		return a, b
-	}
-
-	return b, a
 }
 
 func (c *DeepScan) definitionToRelPath(source common.Reference) string {

--- a/internal/services/checker/checker_imports_test.go
+++ b/internal/services/checker/checker_imports_test.go
@@ -5,11 +5,11 @@ import (
 	"runtime"
 	"testing"
 
-	"github.com/fe3dback/go-arch-lint/internal/models/arch"
-	"github.com/fe3dback/go-arch-lint/internal/models/common"
 	"github.com/stretchr/testify/assert"
 
 	"github.com/fe3dback/go-arch-lint/internal/models"
+	"github.com/fe3dback/go-arch-lint/internal/models/arch"
+	"github.com/fe3dback/go-arch-lint/internal/models/common"
 )
 
 const (

--- a/internal/services/checker/deepscan/ast_utils.go
+++ b/internal/services/checker/deepscan/ast_utils.go
@@ -5,7 +5,6 @@ import (
 	"go/ast"
 	"go/parser"
 	"go/token"
-	"io/fs"
 	"os"
 	"path/filepath"
 	"regexp"
@@ -72,10 +71,9 @@ func parseRecursive(
 	path string,
 	excludedPaths []string,
 	excludedFileMatchers []*regexp.Regexp,
-	filter func(fs.FileInfo) bool,
 	mode parser.Mode,
-) (pkgs map[string]*ast.Package, first error) {
-	pkgs = make(map[string]*ast.Package)
+) (files map[string]*ast.File, first error) {
+	files = make(map[string]*ast.File)
 
 	parseCtx := parseRecursiveCtx{
 		excludedPaths:        excludedPaths,
@@ -90,34 +88,16 @@ func parseRecursive(
 		return nil, fmt.Errorf("failed to walk project tree: %w", err)
 	}
 
-	foundPackages := extractPackagesFromFilePaths(parseCtx.foundFiles)
-	for _, analysePackage := range foundPackages {
-		found, err := parser.ParseDir(fset, analysePackage, filter, mode)
+	for filePath := range parseCtx.foundFiles {
+		fileAst, err := parser.ParseFile(fset, filePath, nil, mode)
 		if err != nil {
-			return nil, fmt.Errorf("failed parse '%s': %w", analysePackage, err)
+			return nil, fmt.Errorf("failed parse '%s': %w", filePath, err)
 		}
 
-		for packageID, astPackage := range found {
-			pkgs[fmt.Sprintf("%s_%s", analysePackage, packageID)] = astPackage
-		}
+		files[filePath] = fileAst
 	}
 
-	return pkgs, nil
-}
-
-func extractPackagesFromFilePaths(paths map[string]struct{}) []string {
-	r := make(map[string]struct{})
-
-	for path := range paths {
-		r[filepath.Dir(path)] = struct{}{}
-	}
-
-	list := make([]string, 0, len(r))
-	for packagePath := range r {
-		list = append(list, packagePath)
-	}
-
-	return list
+	return files, nil
 }
 
 func resolveScopeFile(ctx *parseRecursiveCtx, path string, info os.FileInfo, err error) error {

--- a/internal/services/checker/deepscan/models.go
+++ b/internal/services/checker/deepscan/models.go
@@ -1,6 +1,7 @@
 package deepscan
 
 import (
+	"github.com/fe3dback/go-arch-lint/internal/models"
 	"github.com/fe3dback/go-arch-lint/internal/models/common"
 )
 
@@ -45,9 +46,9 @@ type (
 	}
 
 	Source struct {
-		Pkg    string           // package name (example: "a")
-		Import string           // package full import path (example: "example.com/myProject/internal/a")
-		Path   string           // package full abs path (example: "/home/user/go/src/myProject/internal/a")
-		Place  common.Reference // exactly place in source code
+		Pkg    string                // package name (example: "a")
+		Import models.ResolvedImport // package full import path with type
+		Path   string                // package full abs path (example: "/home/user/go/src/myProject/internal/a")
+		Place  common.Reference      // exactly place in source code
 	}
 )

--- a/internal/services/checker/deepscan/searcher.go
+++ b/internal/services/checker/deepscan/searcher.go
@@ -10,8 +10,10 @@ import (
 	"strings"
 	"sync"
 
-	astUtil "github.com/fe3dback/go-arch-lint/internal/services/common/ast"
 	"golang.org/x/tools/go/packages"
+
+	"github.com/fe3dback/go-arch-lint/internal/models"
+	astUtil "github.com/fe3dback/go-arch-lint/internal/services/common/ast"
 )
 
 type (
@@ -36,7 +38,7 @@ type (
 		// hold all parsed packages in analyse scope
 		// but only with imports declarations
 		// used only for fast filter possible params
-		parsedImports []*ast.Package
+		parsedImports map[string]*ast.File
 
 		// hold all already parsed ast packages
 		// this holds all package meta information
@@ -51,7 +53,7 @@ type (
 func NewSearcher() *Searcher {
 	return &Searcher{
 		ctx: &searchCtx{
-			parsedImports:  []*ast.Package{},
+			parsedImports:  map[string]*ast.File{},
 			parsedPackages: map[absPath]*packages.Package{},
 			fileSet:        token.NewFileSet(),
 		},
@@ -99,15 +101,19 @@ func (s *Searcher) Usages(c Criteria) ([]InjectionMethod, error) {
 
 func (s *Searcher) sourceFromToken(pos token.Pos) Source {
 	place := astUtil.PositionFromToken(s.ctx.fileSet.Position(pos))
-	absPath := filepath.Dir(place.File)
-	importRef := s.pathToImport(absPath)
+	absolutePath := filepath.Dir(place.File)
+	importRef := s.pathToImport(absolutePath)
 	pkg := path.Base(importRef)
 
 	return Source{
-		Pkg:    pkg,
-		Import: importRef,
-		Path:   absPath,
-		Place:  place,
+		Pkg: pkg,
+		Import: models.ResolvedImport{
+			Name:       importRef,
+			ImportType: models.GetImportType(importRef, s.ctx.criteria.moduleName, nil),
+			Reference:  place,
+		},
+		Path:  absolutePath,
+		Place: place,
 	}
 }
 
@@ -129,16 +135,13 @@ func (s *Searcher) preloadImports() error {
 		s.ctx.criteria.analyseScope,
 		s.ctx.criteria.excludePaths,
 		s.ctx.criteria.excludeFileMatchers,
-		nil,
 		parser.ImportsOnly,
 	)
 	if err != nil {
 		return fmt.Errorf("failed parse imports in scope '%s': %w", s.ctx.criteria.analyseScope, err)
 	}
 
-	for _, scopePackage := range found {
-		s.ctx.parsedImports = append(s.ctx.parsedImports, scopePackage)
-	}
+	s.ctx.parsedImports = found
 
 	return nil
 }

--- a/internal/services/checker/deepscan/searcher_find_implementations.go
+++ b/internal/services/checker/deepscan/searcher_find_implementations.go
@@ -43,7 +43,7 @@ func (s *Searcher) extractImports(methods []InjectionMethod) []goImport {
 	result := make(map[goImport]struct{}, 0)
 
 	for _, method := range methods {
-		result[method.Definition.Import] = struct{}{}
+		result[method.Definition.Import.Name] = struct{}{}
 	}
 
 	return mapStrToSlice(result)
@@ -60,18 +60,15 @@ func (s *Searcher) findPackagesWithImport(imports []goImport) ([]packageAbsPath,
 	foundPackagesPath := make(map[packageAbsPath]struct{}, 0)
 	importsMap := sliceStrToMap(imports)
 
-	for _, astPackage := range s.ctx.parsedImports {
-		for filePath, astFile := range astPackage.Files {
-			for _, astImportSpec := range astFile.Imports {
-				if _, ok := importsMap[strings.Trim(astImportSpec.Path.Value, `"`)]; ok {
-					// this file contains useful import
-					packagePath := filepath.Dir(filePath)
-					foundPackagesPath[packagePath] = struct{}{}
-					break
-				}
+	for filePath, astFile := range s.ctx.parsedImports {
+		for _, astImportSpec := range astFile.Imports {
+			if _, ok := importsMap[strings.Trim(astImportSpec.Path.Value, `"`)]; ok {
+				// this file contains useful import
+				packagePath := filepath.Dir(filePath)
+				foundPackagesPath[packagePath] = struct{}{}
+				break
 			}
 		}
-
 	}
 
 	return mapStrToSlice(foundPackagesPath), nil
@@ -107,12 +104,12 @@ func (s *Searcher) applyMethodImplementationsInPackages(method *InjectionMethod,
 			// default alias is same as package name
 			// example `import "path/filepath"`
 			// `filepath` - is default alias
-			importAlias := path.Base(method.Definition.Import)
+			importAlias := path.Base(method.Definition.Import.Name)
 			fileHasCalls := false
 
 			// find importAlias for current file
 			for _, astImport := range astFile.Imports {
-				if strings.Trim(astImport.Path.Value, `"`) != method.Definition.Import {
+				if strings.Trim(astImport.Path.Value, `"`) != method.Definition.Import.Name {
 					continue
 				}
 
@@ -156,7 +153,7 @@ func (s *Searcher) applyMethodImplementationsInPackages(method *InjectionMethod,
 						}
 
 						targetDefinitions := s.sourceFromToken(targetPos)
-						if targetDefinitions.Import == method.Definition.Import {
+						if targetDefinitions.Import.Name == method.Definition.Import.Name {
 							// injector use our public interface for typing
 							// we exclude this cases from more deep analyse, because of runtime
 							// types injection. (we have not known type on compile time)

--- a/internal/services/checker/deepscan/test/project_test.go
+++ b/internal/services/checker/deepscan/test/project_test.go
@@ -6,8 +6,9 @@ import (
 	"runtime"
 	"testing"
 
-	deepscan2 "github.com/fe3dback/go-arch-lint/internal/services/checker/deepscan"
 	"github.com/stretchr/testify/assert"
+
+	"github.com/fe3dback/go-arch-lint/internal/services/checker/deepscan"
 )
 
 func Test1(t *testing.T) {
@@ -18,11 +19,12 @@ func Test1(t *testing.T) {
 	projectDir := filepath.Join(filepath.Dir(callerDir), "project")
 	fmt.Println("project root dir: " + projectDir)
 
-	searcher := deepscan2.NewSearcher()
-	criteria, err := deepscan2.NewCriteria(
-		deepscan2.WithPackagePath(filepath.Join(projectDir, "internal", "operations")),
-		deepscan2.WithAnalyseScope(filepath.Join(projectDir, "internal")),
+	searcher := deepscan.NewSearcher()
+	criteria, err := deepscan.NewCriteria(
+		deepscan.WithPackagePath(filepath.Join(projectDir, "internal", "operations")),
+		deepscan.WithAnalyseScope(filepath.Join(projectDir, "internal")),
 	)
+	assert.NoError(t, err)
 
 	// act
 	expected := test1Expected()
@@ -36,11 +38,11 @@ func Test1(t *testing.T) {
 	// assert.Equal(t, expected, actual)
 }
 
-func test1Expected() []deepscan2.InjectionMethod {
-	return []deepscan2.InjectionMethod{
+func test1Expected() []deepscan.InjectionMethod {
+	return []deepscan.InjectionMethod{
 		{
 			Name:       "hello",
-			Definition: deepscan2.Source{},
+			Definition: deepscan.Source{},
 			Gates:      nil,
 		},
 	}

--- a/internal/services/common/path/resolver.go
+++ b/internal/services/common/path/resolver.go
@@ -7,8 +7,7 @@ import (
 )
 
 type (
-	Resolver struct {
-	}
+	Resolver struct{}
 )
 
 func NewResolver() *Resolver {
@@ -16,9 +15,7 @@ func NewResolver() *Resolver {
 }
 
 func (r Resolver) Resolve(absPath string) (resolvePaths []string, err error) {
-	if strings.HasSuffix(absPath, ".") {
-		absPath = strings.TrimSuffix(absPath, ".")
-	}
+	absPath = strings.TrimSuffix(absPath, ".")
 
 	matches, err := glob(absPath)
 	if err != nil {

--- a/internal/services/common/yaml/reference/resolver.go
+++ b/internal/services/common/yaml/reference/resolver.go
@@ -4,9 +4,10 @@ import (
 	"fmt"
 	"os"
 
-	"github.com/fe3dback/go-arch-lint/internal/models/common"
 	"github.com/fe3dback/go-yaml"
 	"github.com/fe3dback/go-yaml/parser"
+
+	"github.com/fe3dback/go-arch-lint/internal/models/common"
 )
 
 type Resolver struct {

--- a/internal/services/project/holder/holder.go
+++ b/internal/services/project/holder/holder.go
@@ -9,8 +9,7 @@ import (
 )
 
 type (
-	Holder struct {
-	}
+	Holder struct{}
 
 	matchedComponent struct {
 		id         string

--- a/internal/services/project/info/assembler.go
+++ b/internal/services/project/info/assembler.go
@@ -5,14 +5,13 @@ import (
 	"os"
 	"path/filepath"
 
+	"golang.org/x/mod/modfile"
+
 	"github.com/fe3dback/go-arch-lint/internal/models"
 	"github.com/fe3dback/go-arch-lint/internal/models/common"
-
-	"golang.org/x/mod/modfile"
 )
 
-type Assembler struct {
-}
+type Assembler struct{}
 
 func NewAssembler() *Assembler {
 	return &Assembler{}

--- a/internal/services/project/scanner/scanner.go
+++ b/internal/services/project/scanner/scanner.go
@@ -11,9 +11,10 @@ import (
 	"regexp"
 	"strings"
 
+	"golang.org/x/tools/go/packages"
+
 	"github.com/fe3dback/go-arch-lint/internal/models"
 	astUtil "github.com/fe3dback/go-arch-lint/internal/services/common/ast"
-	"golang.org/x/tools/go/packages"
 )
 
 type (
@@ -129,24 +130,10 @@ func (r *Scanner) extractImports(ctx *resolveContext, fileAst *ast.File) []model
 		importPath := strings.Trim(goImport.Path.Value, "\"")
 		imports = append(imports, models.ResolvedImport{
 			Name:       importPath,
-			ImportType: r.getImportType(ctx, importPath),
+			ImportType: models.GetImportType(importPath, ctx.moduleName, r.stdPackages),
 			Reference:  astUtil.PositionFromToken(ctx.tokenSet.Position(goImport.Pos())),
 		})
 	}
 
 	return imports
-}
-
-func (r *Scanner) getImportType(ctx *resolveContext, importPath string) models.ImportType {
-	if _, ok := r.stdPackages[importPath]; ok {
-		return models.ImportTypeStdLib
-	}
-
-	// We can't use a straight prefix match here because the module name could be a substring of the import path.
-	// For example, if the module name is "example.com/foo/bar", we do not want to match "example.com/foo/bar-utils"
-	if importPath == ctx.moduleName || strings.HasPrefix(importPath, ctx.moduleName+"/") {
-		return models.ImportTypeProject
-	}
-
-	return models.ImportTypeVendor
 }

--- a/internal/services/render/ascii_functions.go
+++ b/internal/services/render/ascii_functions.go
@@ -72,12 +72,12 @@ func (r *Renderer) asciiPathDirectory(value interface{}) string {
 func (r *Renderer) asciiPlus(a, b interface{}) (int, error) {
 	iA, err := strconv.Atoi(fmt.Sprintf("%d", a))
 	if err != nil {
-		return 0, fmt.Errorf("A component of 'plus' is not int: %s", a)
+		return 0, fmt.Errorf("component A of 'plus' is not int: %s", a)
 	}
 
 	iB, err := strconv.Atoi(fmt.Sprintf("%d", b))
 	if err != nil {
-		return 0, fmt.Errorf("B component of 'plus' is not int: %s", b)
+		return 0, fmt.Errorf("component B of 'plus' is not int: %s", b)
 	}
 
 	return iA + iB, nil
@@ -86,12 +86,12 @@ func (r *Renderer) asciiPlus(a, b interface{}) (int, error) {
 func (r *Renderer) asciiMinus(a, b interface{}) (int, error) {
 	iA, err := strconv.Atoi(fmt.Sprintf("%d", a))
 	if err != nil {
-		return 0, fmt.Errorf("A component of 'minus' is not int: %s", a)
+		return 0, fmt.Errorf("component A of 'minus' is not int: %s", a)
 	}
 
 	iB, err := strconv.Atoi(fmt.Sprintf("%d", b))
 	if err != nil {
-		return 0, fmt.Errorf("B component of 'minus' is not int: %s", b)
+		return 0, fmt.Errorf("component B of 'minus' is not int: %s", b)
 	}
 
 	return iA + iB, nil

--- a/internal/services/render/code/reader.go
+++ b/internal/services/render/code/reader.go
@@ -9,6 +9,7 @@ import (
 	"github.com/alecthomas/chroma/formatters"
 	"github.com/alecthomas/chroma/lexers"
 	"github.com/alecthomas/chroma/styles"
+
 	"github.com/fe3dback/go-arch-lint/internal/models/common"
 )
 

--- a/internal/services/render/renderer.go
+++ b/internal/services/render/renderer.go
@@ -53,7 +53,7 @@ func NewRenderer(
 
 func (r *Renderer) RenderModel(model interface{}, err error) error {
 	if err != nil && !errors.Is(err, models.UserSpaceError{}) {
-		var referableErr models.ReferableErr
+		var referableErr models.ReferableError
 		if errors.As(err, &referableErr) {
 			codePreview := r.referenceRender.SourceCode(referableErr.Reference().ExtendRange(1, 1), true, true)
 			fmt.Printf("ERR: %s\n", err.Error())

--- a/internal/services/schema/provider.go
+++ b/internal/services/schema/provider.go
@@ -14,8 +14,7 @@ var v2 []byte
 //go:embed v3.json
 var v3 []byte
 
-type Provider struct {
-}
+type Provider struct{}
 
 func NewProvider() *Provider {
 	return &Provider{}

--- a/internal/services/spec/assembler/allowed_project_imports.go
+++ b/internal/services/spec/assembler/allowed_project_imports.go
@@ -9,17 +9,14 @@ import (
 )
 
 type allowedProjectImportsAssembler struct {
-	projectPath string
-	resolver    *resolver
+	resolver *resolver
 }
 
 func newAllowedProjectImportsAssembler(
-	projectPath string,
 	resolver *resolver,
 ) *allowedProjectImportsAssembler {
 	return &allowedProjectImportsAssembler{
-		projectPath: projectPath,
-		resolver:    resolver,
+		resolver: resolver,
 	}
 }
 

--- a/internal/services/spec/assembler/allowed_vendor_imports.go
+++ b/internal/services/spec/assembler/allowed_vendor_imports.go
@@ -6,16 +6,10 @@ import (
 	"github.com/fe3dback/go-arch-lint/internal/services/spec"
 )
 
-type allowedVendorImportsAssembler struct {
-	resolver *resolver
-}
+type allowedVendorImportsAssembler struct{}
 
-func newAllowedVendorImportsAssembler(
-	resolver *resolver,
-) *allowedVendorImportsAssembler {
-	return &allowedVendorImportsAssembler{
-		resolver: resolver,
-	}
+func newAllowedVendorImportsAssembler() *allowedVendorImportsAssembler {
+	return &allowedVendorImportsAssembler{}
 }
 
 func (aia *allowedVendorImportsAssembler) assemble(

--- a/internal/services/spec/assembler/assembler.go
+++ b/internal/services/spec/assembler/assembler.go
@@ -65,12 +65,9 @@ func (sa *Assembler) Assemble(prj common.Project) (arch.Spec, error) {
 		newComponentsAssembler(
 			resolver,
 			newAllowedProjectImportsAssembler(
-				prj.Directory,
 				resolver,
 			),
-			newAllowedVendorImportsAssembler(
-				resolver,
-			),
+			newAllowedVendorImportsAssembler(),
 		),
 		newExcludeAssembler(resolver),
 		newExcludeFilesMatcherAssembler(),

--- a/internal/services/spec/assembler/assembler_ac_allow.go
+++ b/internal/services/spec/assembler/assembler_ac_allow.go
@@ -5,8 +5,7 @@ import (
 	"github.com/fe3dback/go-arch-lint/internal/services/spec"
 )
 
-type allowAssembler struct {
-}
+type allowAssembler struct{}
 
 func newAllowAssembler() *allowAssembler {
 	return &allowAssembler{}

--- a/internal/services/spec/assembler/assembler_ac_workdir.go
+++ b/internal/services/spec/assembler/assembler_ac_workdir.go
@@ -5,8 +5,7 @@ import (
 	"github.com/fe3dback/go-arch-lint/internal/services/spec"
 )
 
-type workdirAssembler struct {
-}
+type workdirAssembler struct{}
 
 func newWorkdirAssembler() *workdirAssembler {
 	return &workdirAssembler{}

--- a/internal/services/spec/decoder/decoder.go
+++ b/internal/services/spec/decoder/decoder.go
@@ -6,10 +6,11 @@ import (
 	"fmt"
 	"os"
 
+	"github.com/fe3dback/go-yaml"
+
 	"github.com/fe3dback/go-arch-lint/internal/models/arch"
 	"github.com/fe3dback/go-arch-lint/internal/models/common"
 	"github.com/fe3dback/go-arch-lint/internal/services/spec"
-	"github.com/fe3dback/go-yaml"
 )
 
 type Decoder struct {

--- a/internal/services/spec/decoder/decoder_yaml.go
+++ b/internal/services/spec/decoder/decoder_yaml.go
@@ -4,8 +4,9 @@ import (
 	"context"
 	"fmt"
 
-	"github.com/fe3dback/go-arch-lint/internal/models/common"
 	"github.com/fe3dback/go-yaml/ast"
+
+	"github.com/fe3dback/go-arch-lint/internal/models/common"
 )
 
 type ref[T any] struct {
@@ -13,8 +14,10 @@ type ref[T any] struct {
 	ref     common.Referable[T]
 }
 
-type stringList []string
-type yamlParentFileCtx struct{}
+type (
+	stringList        []string
+	yamlParentFileCtx struct{}
+)
 
 func (r *ref[T]) UnmarshalYAML(ctx context.Context, node ast.Node, decode func(interface{}) error) error {
 	filePath := ""
@@ -48,7 +51,7 @@ func (s *stringList) UnmarshalYAML(unmarshal func(interface{}) error) error {
 		*s = []string{value}
 		return nil
 	} else {
-		lastErr = fmt.Errorf("%v: %w", lastErr, err)
+		lastErr = fmt.Errorf("%w: %w", lastErr, err)
 	}
 
 	return fmt.Errorf("failed decode yaml stringsList: %w", lastErr)

--- a/internal/services/spec/decoder/decoder_yaml.go
+++ b/internal/services/spec/decoder/decoder_yaml.go
@@ -51,7 +51,7 @@ func (s *stringList) UnmarshalYAML(unmarshal func(interface{}) error) error {
 		*s = []string{value}
 		return nil
 	} else {
-		lastErr = fmt.Errorf("%w: %w", lastErr, err)
+		lastErr = fmt.Errorf("%s: %w", lastErr.Error(), err)
 	}
 
 	return fmt.Errorf("failed decode yaml stringsList: %w", lastErr)

--- a/internal/services/spec/validator/validator.go
+++ b/internal/services/spec/validator/validator.go
@@ -29,7 +29,7 @@ func (v *Validator) Validate(doc spec.Document, projectDir string) []arch.Notice
 		newValidatorDepsComponents(utils),
 		newValidatorDepsVendors(utils),
 		newValidatorExcludeFiles(),
-		newValidatorVendors(utils),
+		newValidatorVendors(),
 		newValidatorVersion(),
 		newValidatorWorkDir(utils),
 	}

--- a/internal/services/spec/validator/validator_exclude_files.go
+++ b/internal/services/spec/validator/validator_exclude_files.go
@@ -8,8 +8,7 @@ import (
 	"github.com/fe3dback/go-arch-lint/internal/services/spec"
 )
 
-type validatorExcludeFiles struct {
-}
+type validatorExcludeFiles struct{}
 
 func newValidatorExcludeFiles() *validatorExcludeFiles {
 	return &validatorExcludeFiles{}
@@ -21,7 +20,7 @@ func (v *validatorExcludeFiles) Validate(doc spec.Document) []arch.Notice {
 	for index, regExp := range doc.ExcludedFilesRegExp() {
 		if _, err := regexp.Compile(regExp.Value); err != nil {
 			notices = append(notices, arch.Notice{
-				Notice: fmt.Errorf("invalid regexp '%s' at %d: %v", regExp.Value, index, err),
+				Notice: fmt.Errorf("invalid regexp '%s' at %d: %w", regExp.Value, index, err),
 				Ref:    regExp.Reference,
 			})
 		}

--- a/internal/services/spec/validator/validator_vendors.go
+++ b/internal/services/spec/validator/validator_vendors.go
@@ -5,16 +5,10 @@ import (
 	"github.com/fe3dback/go-arch-lint/internal/services/spec"
 )
 
-type validatorVendors struct {
-	utils *utils
-}
+type validatorVendors struct{}
 
-func newValidatorVendors(
-	utils *utils,
-) *validatorVendors {
-	return &validatorVendors{
-		utils: utils,
-	}
+func newValidatorVendors() *validatorVendors {
+	return &validatorVendors{}
 }
 
 func (v *validatorVendors) Validate(_ spec.Document) []arch.Notice {


### PR DESCRIPTION
Fix deepscan ignores anyProjectDeps flag
Change Go version to Go 1.25
Add golangci-lint and fix lint errors