### PR TITLE
Fix bug where excluded directories would still be parsed

### DIFF
--- a/internal/services/project/scanner/scanner.go
+++ b/internal/services/project/scanner/scanner.go
@@ -82,11 +82,30 @@ func (r *Scanner) resolveFile(ctx *resolveContext, path string, info os.FileInfo
 		return err
 	}
 
-	if info.IsDir() || !r.inScope(ctx, path) {
+	if info.IsDir() {
+		// Skip descending into excluded directories entirely.
+		if r.isExcludedDir(ctx, path) {
+			return filepath.SkipDir
+		}
+		return nil
+	}
+
+	if !r.inScope(ctx, path) {
 		return nil
 	}
 
 	return r.parse(ctx, path)
+}
+
+func (r *Scanner) isExcludedDir(ctx *resolveContext, path string) bool {
+	for _, excludePath := range ctx.excludePaths {
+		if path == excludePath.AbsPath ||
+			strings.HasPrefix(path, excludePath.AbsPath+string(os.PathSeparator)) {
+			return true
+		}
+	}
+
+	return false
 }
 
 func (r *Scanner) inScope(ctx *resolveContext, path string) bool {

--- a/internal/services/project/scanner/scanner_test.go
+++ b/internal/services/project/scanner/scanner_test.go
@@ -1,0 +1,90 @@
+package scanner_test
+
+import (
+	"context"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/fe3dback/go-arch-lint/internal/models"
+	"github.com/fe3dback/go-arch-lint/internal/services/project/scanner"
+)
+
+// TestScan_SkipsUnreadableExcludedDir reproduces the case where an excluded
+// directory inside the project tree is unreadable (e.g. a root-owned local
+// docker volume). Before the fix the walk descended into it, hit a
+// permission-denied readdir error and aborted the whole scan. Excluded dirs
+// must now be skipped before descending, so the scan succeeds and still
+// returns the in-scope source files.
+func TestScan_SkipsUnreadableExcludedDir(t *testing.T) {
+	if os.Geteuid() == 0 {
+		t.Skip("running as root bypasses directory permissions; cannot simulate an unreadable dir")
+	}
+
+	projectDir := t.TempDir()
+
+	goFile := filepath.Join(projectDir, "main.go")
+	if err := os.WriteFile(goFile, []byte("package main\n"), 0o644); err != nil {
+		t.Fatalf("write source file: %v", err)
+	}
+
+	excludedDir := filepath.Join(projectDir, ".data")
+	if err := os.Mkdir(excludedDir, 0o755); err != nil {
+		t.Fatalf("mkdir excluded dir: %v", err)
+	}
+	// A subdir the walker would try to readdir into; made unreadable so that
+	// descending into it fails, mirroring the root-owned postgres data dir.
+	unreadable := filepath.Join(excludedDir, "pgdata")
+	if err := os.Mkdir(unreadable, 0o000); err != nil {
+		t.Fatalf("mkdir unreadable dir: %v", err)
+	}
+	// Restore perms so t.TempDir cleanup can remove it.
+	t.Cleanup(func() { _ = os.Chmod(unreadable, 0o755) })
+
+	excludePaths := []models.ResolvedPath{{
+		LocalPath: ".data",
+		AbsPath:   excludedDir,
+	}}
+
+	files, err := scanner.NewScanner().Scan(context.Background(), projectDir, "example.com/proj", excludePaths, nil)
+	if err != nil {
+		t.Fatalf("scan should skip the excluded unreadable dir, got error: %v", err)
+	}
+
+	if len(files) != 1 || files[0].Path != goFile {
+		t.Fatalf("expected only %q to be scanned, got %+v", goFile, files)
+	}
+}
+
+// TestScan_DoesNotDescendIntoExcludedDir asserts that .go files living inside
+// an excluded directory are never scanned.
+func TestScan_DoesNotDescendIntoExcludedDir(t *testing.T) {
+	projectDir := t.TempDir()
+
+	kept := filepath.Join(projectDir, "keep.go")
+	if err := os.WriteFile(kept, []byte("package main\n"), 0o644); err != nil {
+		t.Fatalf("write kept file: %v", err)
+	}
+
+	excludedDir := filepath.Join(projectDir, "vendor")
+	if err := os.Mkdir(excludedDir, 0o755); err != nil {
+		t.Fatalf("mkdir excluded dir: %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(excludedDir, "dep.go"), []byte("package vendor\n"), 0o644); err != nil {
+		t.Fatalf("write excluded file: %v", err)
+	}
+
+	excludePaths := []models.ResolvedPath{{
+		LocalPath: "vendor",
+		AbsPath:   excludedDir,
+	}}
+
+	files, err := scanner.NewScanner().Scan(context.Background(), projectDir, "example.com/proj", excludePaths, nil)
+	if err != nil {
+		t.Fatalf("unexpected scan error: %v", err)
+	}
+
+	if len(files) != 1 || files[0].Path != kept {
+		t.Fatalf("expected only %q to be scanned, got %+v", kept, files)
+	}
+}


### PR DESCRIPTION
I faced an issue where I had a directory inside my project called `.data/pgdata` that was created by `docker-compose`'s postgres container and would persist the db data there. The problem is that docker runs as root and that dir is not meant to be read by the linter.

So I added the `.data` dir to the exclusion rules as I do with .gitignore and .dockerignore, but the linter would still fail with the error:

```
failed to check project deps: ... failed to walk project tree:
open /path/to/project/.data/pgdata: permission denied
```

The reason was that even though that dir was not really going to be parsed, the code was still walking over it and trying to open it. This PR makes the minimum change necessary for to fix this error without changing any existing logic.

Thanks for the great tool. I hope this PR is helpful.