### PR TITLE
Fix deep-scan panic on multi-value return argument tuple (#85)

### DIFF
--- a/internal/services/checker/deepscan/searcher_find_implementations.go
+++ b/internal/services/checker/deepscan/searcher_find_implementations.go
@@ -133,6 +133,15 @@ func (s *Searcher) applyMethodImplementationsInPackages(method *InjectionMethod,
 					if gate.IsVariadic && len(callExpr.Args) <= gate.Index {
 						continue
 					}
+
+					// a multi-value return passed as a single argument tuple
+					// (foo(bar())) collapses several callee parameters into one
+					// callExpr.Args entry, so a non-variadic gate index can exceed
+					// the available arguments. the tupled argument can't be resolved
+					// to an individual injector, so skip it.
+					if !gate.IsVariadic && len(callExpr.Args) <= gate.Index {
+						continue
+					}
 					maxIdx := gate.Index
 					if gate.IsVariadic {
 						// variadic function arguments are passed as individual elements in callExpr.Args

--- a/internal/services/checker/deepscan/test/project_issue85/go.mod
+++ b/internal/services/checker/deepscan/test/project_issue85/go.mod
@@ -1,0 +1,3 @@
+module archlint_issue85
+
+go 1.21

--- a/internal/services/checker/deepscan/test/project_issue85/internal/utils.go
+++ b/internal/services/checker/deepscan/test/project_issue85/internal/utils.go
@@ -1,0 +1,11 @@
+package internal
+
+// Must mirrors the two-parameter (value, error) helper from issue #85. The
+// error parameter is an interface, so deep-scan tracks it as a gate.
+func Must[T any](v T, err error) T {
+	if err != nil {
+		panic(err)
+	}
+
+	return v
+}

--- a/internal/services/checker/deepscan/test/project_issue85/main.go
+++ b/internal/services/checker/deepscan/test/project_issue85/main.go
@@ -1,0 +1,13 @@
+package main
+
+import "archlint_issue85/internal"
+
+func retSomething() (int, error) {
+	return 42, nil
+}
+
+// main passes a multi-value return as a single argument tuple (foo(bar())).
+// deep-scan used to panic with index-out-of-range when walking such a call.
+func main() {
+	_ = internal.Must(retSomething())
+}

--- a/internal/services/checker/deepscan/test/project_test.go
+++ b/internal/services/checker/deepscan/test/project_test.go
@@ -47,3 +47,21 @@ func test1Expected() []deepscan.InjectionMethod {
 		},
 	}
 }
+
+func TestIssue85MultiReturnTuple(t *testing.T) {
+	// Regression for issue #85: a multi-value return spread as a single
+	// argument tuple (foo(bar())) gives callExpr.Args fewer entries than the
+	// callee has parameters, which used to panic the deep-scan argument walk.
+	_, callerDir, _, _ := runtime.Caller(0)
+	projectDir := filepath.Join(filepath.Dir(callerDir), "project_issue85")
+
+	searcher := deepscan.NewSearcher()
+	criteria, err := deepscan.NewCriteria(
+		deepscan.WithPackagePath(filepath.Join(projectDir, "internal")),
+		deepscan.WithAnalyseScope(projectDir),
+	)
+	assert.NoError(t, err)
+
+	_, err = searcher.Usages(criteria)
+	assert.NoError(t, err)
+}


### PR DESCRIPTION
Fixes #85.

## Problem

`go-arch-lint check` panics with `index out of range` on valid Go that passes a multi-value return as a single argument tuple, e.g. `foo(bar())` where `bar()` returns two values:

```go
func Must[T any](v T, err error) T { ... }
func retSomething() (int, error) { ... }
func main() { _ = Must(retSomething()) }
```

In `applyMethodImplementationsInPackages` (`internal/services/checker/deepscan/searcher_find_implementations.go`), the gate loop indexes `callExpr.Args[idx]` up to `gate.Index`. A tuple-spread call collapses several callee parameters into a single `callExpr.Args` entry, so for a non-variadic gate `gate.Index` can exceed `len(callExpr.Args)` and panic. The variadic case already guards this (`if gate.IsVariadic && len(callExpr.Args) <= gate.Index { continue }`), but the non-variadic case did not.

```
panic: runtime error: index out of range [1] with length 1
  .../searcher_find_implementations.go:144
```

## Fix

Add the symmetric bounds guard for the non-variadic case. A tupled argument cannot be resolved to an individual injector, so it is skipped, consistent with the file's existing "unknown injection type ... continue" handling.

## Test

Added `TestIssue85MultiReturnTuple`, which runs the searcher over a small self-contained fixture (`test/project_issue85/`) reproducing the reported `foo(bar())` case. Verified red before the fix (it panics with the exact index-out-of-range) and green after. `go test ./internal/services/checker/deepscan/...`, `gofmt`, and `go vet` all pass locally.

Note: an unrelated golden-file test, `TestCLI/test/selfInspect/arch1_invalid_spec`, already fails on `master` independently of this change (diagnostic-message ordering), so it is not affected by this PR.

---

Disclosure: developed with the assistance of Claude Code (AI); reviewed and verified by me.
